### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/srinivaspeela/544b45c1-0270-490f-a30c-622414873f6e/cef68a1c-ef6e-4bdd-b91b-23b61048c470/_apis/work/boardbadge/089196d8-a856-4389-ab58-4be20d722b31)](https://dev.azure.com/srinivaspeela/544b45c1-0270-490f-a30c-622414873f6e/_boards/board/t/cef68a1c-ef6e-4bdd-b91b-23b61048c470/Microsoft.RequirementCategory)
 Calculator.js: a node.js Demonstration Project
 ==============================================
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#483](https://dev.azure.com/srinivaspeela/544b45c1-0270-490f-a30c-622414873f6e/_workitems/edit/483). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.